### PR TITLE
Prevent 'watch' task from exiting on webpack error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,10 @@ var autoprefixerBrowsers = [
 gulp.task('scripts', function() {
   return gulp.src(webpackConfig.entry)
     .pipe($.webpackStream(webpackConfig))
+    .on('error', function(error) {
+      $.util.log($.util.colors.red(error.message));
+      this.emit('end');
+    })
     .pipe(gulp.dest(dist + 'js/'))
     .pipe($.size({ title : 'js' }))
     .pipe($.connect.reload());


### PR DESCRIPTION
The watch task currently exits if it encounters a JavaScript or Handlebars syntax error.

This patch catches the error, prints it to the console, and allows the watch task to continue such that subsequent edits to the JavaScript or Handlebars source files which fix the syntax error will be picked up and reloaded automatically.
